### PR TITLE
CO-3413 Payments import in other currency take correspondance in default one

### DIFF
--- a/account_bank_statement_import_camt_oca/models/parser.py
+++ b/account_bank_statement_import_camt_oca/models/parser.py
@@ -24,10 +24,12 @@ class CamtParser(models.AbstractModel):
                 '../../ns:CdtDbtInd', namespaces={'ns': ns})
         if sign_node and sign_node[0].text == 'DBIT':
             sign = -1
-        amount_node = node.xpath('ns:Amt', namespaces={'ns': ns})
+        amount_node = node.xpath('../../ns:Amt', namespaces={'ns': ns})
         if not amount_node:
-            amount_node = node.xpath(
-                './ns:AmtDtls/ns:TxAmt/ns:Amt', namespaces={'ns': ns})
+            amount_node = node.xpath('ns:Amt', namespaces={'ns': ns})
+            if not amount_node:
+                amount_node = node.xpath(
+                    './ns:AmtDtls/ns:TxAmt/ns:Amt', namespaces={'ns': ns})
         if amount_node:
             amount = sign * float(amount_node[0].text)
         return amount


### PR DESCRIPTION
Previously, the amount contained in the tag `<AmtDtls>` was taken to determine the amount to pay. The issue is that when the currency of the payment is different than the default one, the amount is taken is the other currency, but it is displayed to be in the default one (150.00 CHF instead of either 150.00 EUR or 156.59 CHF), cf. joined picture. The chosen solution is to use the corresponding amount (`<Amt>` tag) in default currency, directly found in the `<Ntry>` one.

![hidden](https://user-images.githubusercontent.com/20174853/89393242-cf8d2500-d70a-11ea-8aa3-0715fb185ebc.png)
