### PR TITLE
T1747 - Tax deduction bug following T0455

### DIFF
--- a/account_statement_import_camt/models/parser.py
+++ b/account_statement_import_camt/models/parser.py
@@ -277,8 +277,11 @@ class CamtParser(models.AbstractModel):
                     if nboftxs > 1:
                         xchgrate = float(node.xpath("../../ns:AmtDtls/ns:TxAmt/ns:CcyXchg/ns:XchgRate", namespaces={"ns": ns})[0].text)
                         transaction["amount"] = amount*xchgrate
-                else:
-                    transaction["amount"] = amount
+                    else:
+                        if transaction["charges_incl"] == "true":
+                            transaction["amount"] = amount - float(transaction["charges"])
+                        else:
+                            transaction["amount"] = amount
             else:
                 transaction["amount"] = amount
 


### PR DESCRIPTION
When importing an XML statement file (OCA), if an entry contains <NtryDtls> description lines, the fix from task T0455 does not apply the correct amount. This issue arises due to a bug in handling exchange rate errors between currencies.