### PR TITLE
T1804 - Bug with CAMT053 import

### DIFF
--- a/account_statement_import_camt/models/parser.py
+++ b/account_statement_import_camt/models/parser.py
@@ -282,6 +282,8 @@ class CamtParser(models.AbstractModel):
                             transaction["amount"] = amount - float(transaction["charges"])
                         else:
                             transaction["amount"] = amount
+                else:
+                    transaction["amount"] = amount
             else:
                 transaction["amount"] = amount
 


### PR DESCRIPTION
During a CAMT053 import, if payments are grouped, the import process creates a line for each individual payment. However, the amount shown on these lines corresponds to the total group amount, rather than the individual payment amounts.